### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module promgrep
+module github.com/sourcegraph/promgrep
 
 go 1.13


### PR DESCRIPTION
`go get github.com/sourcegraph/promgrep` fails because the module is declared as `promgrep`, not `github.com/sourcegraph/promgrep`
```go get github.com/sourcegraph/promgrep
go: github.com/sourcegraph/promgrep upgrade => v0.0.0-20200605190737-f502e481bbc0
go get: github.com/sourcegraph/promgrep@v0.0.0-20200605190737-f502e481bbc0: parsing go.mod:
	module declares its path as: promgrep
	        but was required as: github.com/sourcegraph/promgrep
```